### PR TITLE
Fix depreciation warnings about importing React from React-Native pac…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
-import React, {
-  Component,
+import React, {Component} from 'react';
+import {
   View,
   Text,
   Image,


### PR DESCRIPTION
Requiring React API from react-native is now deprecated from 0.25
facebook/react-native@0b534d1
facebook/react-native@2eafcd4
https://github.com/facebook/react-native/releases/tag/v0.25.1

Used https://github.com/sibeliusseraphini/codemod-RN24-to-RN25