### PR TITLE
Add real date parameter to onDateChange callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ class DatePicker extends Component {
 
   datePicked() {
     if (typeof this.props.onDateChange === 'function') {
-      this.props.onDateChange(this.getDateStr(this.state.date));
+      this.props.onDateChange(this.getDateStr(this.state.date), this.state.date);
     }
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -141,13 +141,12 @@ describe('DatePicker:', () => {
     const onDateChange = sinon.spy();
     const wrapper = shallow(<DatePicker onDateChange={onDateChange}/>);
     const datePicker = wrapper.instance();
-    wrapper.setState({
-      date: new Date('2016-06-06')
-    });
+    const date = new Date('2016-06-06');
+    wrapper.setState({date});
 
     datePicker.datePicked();
 
-    expect(onDateChange.calledWith('2016-06-06')).to.equal(true);
+    expect(onDateChange.calledWith('2016-06-06', date)).to.equal(true);
   });
 
   it('onDatePicked', () => {


### PR DESCRIPTION
added the real date object to the onDateChange callback so that we don't have to parse the date again when we want to send it to the server.