### PR TITLE
Add modalOnResponderTerminationRequest property

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ You can check [index.js](https://github.com/xgfe/react-native-datepicker/blob/ma
 | showIcon | true | `boolean` | Controller whether or not show the icon |
 | placeholder | '' | `string` | The placeholder show when this.props.date is falsy |
 | onDateChange | - | `function` | This is called when the user confirm the picked date or time in the UI. The first and only argument is a date or time string representing the new date and time formatted by [moment.js](http://momentjs.com/) with the given format property. |
+| modalOnResponderTerminationRequest | - | `function` | Set the callback for React Native's [Gesture Responder System](https://facebook.github.io/react-native/docs/gesture-responder-system.html#responder-lifecycle)'s call to `onResponderTerminationRequest`. By default this will reject a termination request, but can be overidden in case the View under the Modal is implementing custom gesture responders, and you wish for those to be overidden in certain cases.  |
 
 ## Instance Methods
 

--- a/index.js
+++ b/index.js
@@ -256,6 +256,9 @@ class DatePicker extends Component {
               >
                 <Animated.View
                   style={[Style.datePickerCon, {height: this.state.animatedHeight}, customStyles.datePickerCon]}
+                  onStartShouldSetResponder={e => true}
+                  onMoveShouldSetResponder={e => true}
+                  onResponderTerminationRequest={e => !this.props.modalRejectTerminationRequest}
                 >
                   <DatePickerIOS
                     date={this.state.date}
@@ -309,7 +312,8 @@ DatePicker.defaultProps = {
   // whether or not show the icon
   showIcon: true,
   disabled: false,
-  placeholder: ''
+  placeholder: '',
+  modalRejectTerminationRequest: false
 };
 
 DatePicker.propTypes = {
@@ -326,7 +330,8 @@ DatePicker.propTypes = {
   showIcon: React.PropTypes.bool,
   disabled: React.PropTypes.bool,
   onDateChange: React.PropTypes.func,
-  placeholder: React.PropTypes.string
+  placeholder: React.PropTypes.string,
+  modalRejectTerminationRequest: React.PropTypes.bool
 };
 
 export default DatePicker;

--- a/index.js
+++ b/index.js
@@ -258,7 +258,7 @@ class DatePicker extends Component {
                   style={[Style.datePickerCon, {height: this.state.animatedHeight}, customStyles.datePickerCon]}
                   onStartShouldSetResponder={e => true}
                   onMoveShouldSetResponder={e => true}
-                  onResponderTerminationRequest={e => !this.props.modalRejectTerminationRequest}
+                  onResponderTerminationRequest={this.props.modalOnResponderTerminationRequest}
                 >
                   <DatePickerIOS
                     date={this.state.date}
@@ -313,7 +313,7 @@ DatePicker.defaultProps = {
   showIcon: true,
   disabled: false,
   placeholder: '',
-  modalRejectTerminationRequest: false
+  modalOnResponderTerminationRequest: e => true
 };
 
 DatePicker.propTypes = {
@@ -331,7 +331,7 @@ DatePicker.propTypes = {
   disabled: React.PropTypes.bool,
   onDateChange: React.PropTypes.func,
   placeholder: React.PropTypes.string,
-  modalRejectTerminationRequest: React.PropTypes.bool
+  modalOnResponderTerminationRequest: React.PropTypes.func
 };
 
 export default DatePicker;


### PR DESCRIPTION
Was having issues where a custom Gesture Responder on one of my views was being triggered when scrolling up and down on the iOS Date Picker Modal. Added this property to override `onResponderTerminationRequest` callback on the Date Picker Modal.

By default the behaviour will be the same as before.
