### PR TITLE
Add animation on datepicker dismiss

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,10 +52,9 @@ class DatePicker extends Component {
   setModalVisible(visible) {
     const {height, duration} = this.props;
 
-    this.setState({modalVisible: visible});
-
     // slide animation
     if (visible) {
+      this.setState({modalVisible: visible});
       Animated.timing(
         this.state.animatedHeight,
         {
@@ -64,8 +63,14 @@ class DatePicker extends Component {
         }
       ).start();
     } else {
-      this.setState({
-        animatedHeight: new Animated.Value(0)
+      Animated.timing(
+        this.state.animatedHeight,
+        {
+          toValue: 0,
+          duration: duration
+        }
+      ).start(() => {
+        this.setState({modalVisible: visible});
       });
     }
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -156,15 +156,19 @@ describe('DatePicker:', () => {
     const wrapper = shallow(<DatePicker />);
     const datePicker = wrapper.instance();
 
-    datePicker.setModalVisible(true);
+    new Promise(function(resolve, reject) {
+      datePicker.setModalVisible(true);
+    }).then((result) => {
+      expect(wrapper.state('modalVisible')).to.equal(true);
+      expect(wrapper.state('animatedHeight')._animation._toValue).to.above(200);
+    })
 
-    expect(wrapper.state('modalVisible')).to.equal(true);
-    expect(wrapper.state('animatedHeight')._animation._toValue).to.above(200);
-
-    datePicker.setModalVisible(false);
-
-    expect(wrapper.state('modalVisible')).to.equal(false);
-    expect(wrapper.state('animatedHeight')).to.deep.equal(new Animated.Value(0));
+    new Promise(function(resolve, reject) {
+      datePicker.setModalVisible(false);
+    }).then((result) => {
+      expect(wrapper.state('modalVisible')).to.equal(false);
+      expect(wrapper.state('animatedHeight')).to.deep.equal(new Animated.Value(0));
+    });
   });
 
   it('onPressCancel', () => {


### PR DESCRIPTION
Currently the datepicker just dismisses without any animation; this adds animation to the dismiss for a smoother transition and modifies the tests for that to pass.

Corresponds to issue: https://github.com/xgfe/react-native-datepicker/issues/61