### PR TITLE
Added two new properties: onOpenModal and onCloseModal

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,11 +80,19 @@ class DatePicker extends Component {
 
   onPressCancel() {
     this.setModalVisible(false);
+
+    if (typeof this.props.onCloseModal === 'function') {
+      this.props.onCloseModal();
+    }
   }
 
   onPressConfirm() {
     this.datePicked();
     this.setModalVisible(false);
+
+    if (typeof this.props.onCloseModal === 'function') {
+      this.props.onCloseModal();
+    }
   }
 
   getDate(date = this.props.date) {
@@ -228,6 +236,10 @@ class DatePicker extends Component {
         }).then(this.onDatetimePicked);
       }
     }
+
+    if (typeof this.props.onOpenModal === 'function') {
+      this.props.onOpenModal();
+    }
   }
 
   render() {
@@ -361,6 +373,8 @@ DatePicker.propTypes = {
   showIcon: React.PropTypes.bool,
   disabled: React.PropTypes.bool,
   onDateChange: React.PropTypes.func,
+  onOpenModal: React.PropTypes.func,
+  onCloseModal: React.PropTypes.func,
   placeholder: React.PropTypes.string,
   modalOnResponderTerminationRequest: React.PropTypes.func,
   is24Hour: React.PropTypes.bool


### PR DESCRIPTION
I added two function properties that are invoked when the modal appears and disappears off of the screen.  I'm working on a time-keeping app that has an array of time pickers. The new properties allow me to change the background color of the currently opened time picker so that the user is able to easily distinguish which input is active.

The function onCloseModal is called at the end of onPressConfirm and onPressCancel.
The function onOpenModal is called at the end of onPressDate.

Also, I believe this might solve issues raised by some users. #72 