### PR TITLE
Remove hard coded width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-datepicker",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "react native datePicker component for both Android and IOS, useing DatePikcerAndroid, TimePickerAndroid and DatePickerIOS",
   "main": "index.js",
   "scripts": {

--- a/style.js
+++ b/style.js
@@ -2,6 +2,7 @@ import {StyleSheet} from 'react-native';
 
 let style = StyleSheet.create({
   dateTouch: {
+    flexDirection: "row",
   },
   dateTouchBody: {
     flexDirection: 'row',

--- a/style.js
+++ b/style.js
@@ -2,7 +2,6 @@ import {StyleSheet} from 'react-native';
 
 let style = StyleSheet.create({
   dateTouch: {
-    width: 142
   },
   dateTouchBody: {
     flexDirection: 'row',


### PR DESCRIPTION
### Desc 

Sometimes when the placeholder text run long it warps because of the `width` limitations. This PR is removing the limitations so that the user can have more control over how the placeholder is presented