### PR TITLE
setState when new date prop is received

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,12 @@ class DatePicker extends Component {
     ];
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.date !== this.props.date) {
+      this.setState({date: this.getDate(nextProps.date)});
+    }
+  }
+
   setModalVisible(visible) {
     const {height, duration} = this.props;
 


### PR DESCRIPTION
When I open the datepicker it opens up to the current date/time on the calendar even though the display string is some other datetime I passed it. This is because redux initially passes null as the date prop, but, after some time passes an actual date string - however, when it passes the actual date string the datepicker component doesn't update the state for date.