### PR TITLE
Allow for custom display/rendered format 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ export default class MyDatePicker extends Component {
         date={this.state.date}
         mode="date"
         placeholder="select date"
+        displayFormat="dddd, MMMM Do"
         format="YYYY-MM-DD"
         minDate="2016-05-01"
         maxDate="2016-06-01"
@@ -66,7 +67,8 @@ You can check [index.js](https://github.com/xgfe/react-native-datepicker/blob/ma
 | style | - | `object` | Specify the style of the DatePicker, eg. width, height...  |
 | date | - | `string | date` | Specify the display date of DatePicker. `string` type value must match the specified format  |
 | mode | 'date' | `enum` | The `enum` of `date`, `datetime` and `time` |
-| format | 'YYYY-MM-DD' | `string` | Specify the display format of the date, which using [moment.js](http://momentjs.com/). The default value change according to the mode. |
+| format | 'YYYY-MM-DD' | `string` | Specify the internal format used for the date, which using [moment.js](http://momentjs.com/). The default value change according to the mode. |
+| displayFormat | `format` | `string` | Specify the display/rendered format of the date, which using [moment.js](http://momentjs.com/). The default value will fall back to `format`, or change according to the mode. |
 | confirmBtnText | '确定' | `string` | Specify the text of confirm btn in ios. |
 | cancelBtnText | '取消' | `string` | Specify the text of cancel btn in ios. |
 | iconSource | - | `{uri: string} | number` | Specify the icon. Same as the `source` of Image, always using `require()` |

--- a/index.js
+++ b/index.js
@@ -133,14 +133,15 @@ class DatePicker extends Component {
 
     return Moment(date, format).toDate();
   }
-
-  getDateStr(date = this.props.date) {
-    const {mode, format = FORMATS[mode]} = this.props;
-
+  
+  getDateStr(date = this.props.date, display = false) {
+    const { mode, displayFormat, format = FORMATS[mode] } = this.props;
+    const strFormat = display && displayFormat ? displayFormat : format;
+    
     if (date instanceof Date) {
-      return Moment(date).format(format);
+      return Moment(date).format(strFormat);
     } else {
-      return Moment(this.getDate(date)).format(format);
+      return Moment(this.getDate(date)).format(strFormat);
     }
   }
 
@@ -156,7 +157,7 @@ class DatePicker extends Component {
     if (!date && placeholder) {
       return (<Text style={[Style.placeholderText, customStyles.placeholderText]}>{placeholder}</Text>);
     }
-    return (<Text style={[Style.dateText, customStyles.dateText]}>{this.getDateStr()}</Text>);
+    return (<Text style={[Style.dateText, customStyles.dateText]}>{this.getDateStr(date, true)}</Text>);
   }
 
   onDatePicked({action, year, month, day}) {
@@ -371,6 +372,7 @@ DatePicker.propTypes = {
   mode: React.PropTypes.oneOf(['date', 'datetime', 'time']),
   date: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.instanceOf(Date)]),
   format: React.PropTypes.string,
+  displayFormat: React.PropTypes.string,
   minDate: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.instanceOf(Date)]),
   maxDate: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.instanceOf(Date)]),
   height: React.PropTypes.number,


### PR DESCRIPTION
I believe the library should allow developers to display/render a date format that is separate from the internal format used in the code. Reason for this is to **allow for custom, non-standard, format display... while at the same time maintaining a standard, internal, format that is easier to handle with code.** 

I didn't want to change too much code and wanted to stay aligned with the style used throughout the source.

Commit Notes:
Changes the `getDateStr()` signature to accept `display` boolean. This boolean paired with a given prop `displayFormat` allows for rendering the date as a separate format (breaking the lock between intended "display format" and date format used throughout the src)

Related Issues:
#30 
#92 
#29 