### PR TITLE
Add locale support

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,12 +135,12 @@ class DatePicker extends Component {
   }
 
   getDateStr(date = this.props.date) {
-    const {mode, format = FORMATS[mode]} = this.props;
+    const {mode, locale, format = FORMATS[mode]} = this.props;
 
     if (date instanceof Date) {
-      return Moment(date).format(format);
+      return Moment(date).locale(locale).format(format);
     } else {
-      return Moment(this.getDate(date)).format(format);
+      return Moment(this.getDate(date)).locale(locale).format(format);
     }
   }
 
@@ -350,6 +350,7 @@ class DatePicker extends Component {
 DatePicker.defaultProps = {
   mode: 'date',
   date: '',
+  locale: 'en',
   // component height: 216(DatePickerIOS) + 1(borderTop) + 42(marginTop), IOS only
   height: 259,
 
@@ -371,6 +372,7 @@ DatePicker.propTypes = {
   mode: React.PropTypes.oneOf(['date', 'datetime', 'time']),
   date: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.instanceOf(Date)]),
   format: React.PropTypes.string,
+  locale: React.PropTypes.string,
   minDate: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.instanceOf(Date)]),
   maxDate: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.instanceOf(Date)]),
   height: React.PropTypes.number,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -217,6 +217,9 @@ describe('DatePicker:', () => {
 
     wrapper.setProps({format: 'YYYY/MM/DD'});
     expect(datePicker.getDateStr(new Date('2016-06-02'))).to.equal('2016/06/02');
+
+    wrapper.setProps({format: "ddd, DD MMM YYYY", locale: "pt-br"});
+    expect(datePicker.getDateStr()).to.equal('Qua, 20 Jan 2016');
   });
 
   it('datePicked', () => {


### PR DESCRIPTION
Allow DatePicker to receive locale as props.

The locale is used in the `getDateStr` method, so that the date text is displayed according to the locale.

Example of usage:

```
<DatePicker
    date="2016-06-01"
    format="ddd, DDDD MMM YYYY"
    locale="pt-br" />
```

Related issues:
* #71 
* #91 