### PR TITLE
Avoid overwriting user-set ignored warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,10 +52,10 @@ class DatePicker extends Component {
 
   componentWillMount() {
     // ignore the warning of Failed propType for date of DatePickerIOS, will remove after being fixed by official
-    console.ignoredYellowBox = [
-      'Warning: Failed propType'
-      // Other warnings you don't want like 'jsSchedulingOverhead',
-    ];
+    if (!console.ignoredYellowBox) {
+      console.ignoredYellowBox = [];
+    }
+    console.ignoredYellowBox.push('Warning: Failed propType');
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Current implementation overwrites any user-set warnings, this PR resolves that.