### PR TITLE
Fix: use moment's no dynamic import version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/xgfe/react-native-datepicker#readme",
   "dependencies": {
-    "moment": "2.x.x"
+    "moment": "moment/moment#4187/head"
   },
   "devDependencies": {
     "babel-core": "^6.5.2",


### PR DESCRIPTION
react-native 0.49 does not work with dynamic imports. They are used in moment.