### PR TITLE
Add support for allowFontScaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ You can check [index.js](https://github.com/xgfe/react-native-datepicker/blob/ma
 | iconComponent | - | `element` | Set the custom icon |
 | disabled | false | `boolean` | Controller whether or not disable the picker |
 | is24Hour | - | `boolean` | Set the TimePicker is24Hour flag. The default value depend on `format`. Only work in Android |
+| allowFontScaling | true | `boolean` | Set to false to disable font scaling for every text component |
 | placeholder | '' | `string` | The placeholder show when this.props.date is falsy |
 | onDateChange | - | `function` | This is called when the user confirm the picked date or time in the UI. The first and only argument is a date or time string representing the new date and time formatted by [moment.js](http://momentjs.com/) with the given format property. |
 | onOpenModal | - | `function` | This is called when the DatePicker Modal open. |

--- a/datepicker.js
+++ b/datepicker.js
@@ -172,12 +172,12 @@ class DatePicker extends Component {
   }
 
   getTitleElement() {
-    const {date, placeholder, customStyles} = this.props;
+    const {date, placeholder, customStyles, allowFontScaling} = this.props;
 
     if (!date && placeholder) {
-      return (<Text style={[Style.placeholderText, customStyles.placeholderText]}>{placeholder}</Text>);
+      return (<Text allowFontScaling={allowFontScaling} style={[Style.placeholderText, customStyles.placeholderText]}>{placeholder}</Text>);
     }
-    return (<Text style={[Style.dateText, customStyles.dateText]}>{this.getDateStr()}</Text>);
+    return (<Text allowFontScaling={allowFontScaling} style={[Style.dateText, customStyles.dateText]}>{this.getDateStr()}</Text>);
   }
 
   onDateChange(date) {
@@ -334,7 +334,8 @@ class DatePicker extends Component {
       TouchableComponent,
       testID,
       cancelBtnTestID,
-      confirmBtnTestID
+      confirmBtnTestID,
+      allowFontScaling
     } = this.props;
 
     const dateInputStyle = [
@@ -402,6 +403,7 @@ class DatePicker extends Component {
                       testID={cancelBtnTestID}
                     >
                       <Text
+                        allowFontScaling={allowFontScaling}
                         style={[Style.btnTextText, Style.btnTextCancel, customStyles.btnTextCancel]}
                       >
                         {cancelBtnText}
@@ -413,7 +415,7 @@ class DatePicker extends Component {
                       style={[Style.btnText, Style.btnConfirm, customStyles.btnConfirm]}
                       testID={confirmBtnTestID}
                     >
-                      <Text style={[Style.btnTextText, customStyles.btnTextConfirm]}>{confirmBtnText}</Text>
+                      <Text allowFontScaling={allowFontScaling} style={[Style.btnTextText, customStyles.btnTextConfirm]}>{confirmBtnText}</Text>
                     </TouchableComponent>
                   </Animated.View>
                 </TouchableComponent>
@@ -443,6 +445,7 @@ DatePicker.defaultProps = {
   // whether or not show the icon
   showIcon: true,
   disabled: false,
+  allowFontScaling: true,
   hideText: false,
   placeholder: '',
   TouchableComponent: TouchableHighlight,
@@ -465,6 +468,7 @@ DatePicker.propTypes = {
   customStyles: PropTypes.object,
   showIcon: PropTypes.bool,
   disabled: PropTypes.bool,
+  allowFontScaling: PropTypes.bool,
   onDateChange: PropTypes.func,
   onOpenModal: PropTypes.func,
   onCloseModal: PropTypes.func,


### PR DESCRIPTION
All the text elements in the datepicker had the default value of allowFontScaling={true} and there was no way to change that. I would like to use this component but have the option to turn font scaling off. So i added a new property with the same name, and then put in the logic next to all the <Text components. I do not know your code base like at all. I did all these changes in the last half hour, so I may have missed other places there are <text> but i think i got em all. Let me know what you think about the changes. 