### PR TITLE
if timezoneOffset is undefined, pass null to the iOS dateTime picker.…

### DIFF
--- a/datepicker.js
+++ b/datepicker.js
@@ -391,7 +391,7 @@ class DatePicker extends Component {
                         maximumDate={maxDate && this.getDate(maxDate)}
                         onDateChange={this.onDateChange}
                         minuteInterval={minuteInterval}
-                        timeZoneOffsetInMinutes={timeZoneOffsetInMinutes}
+                        timeZoneOffsetInMinutes={timeZoneOffsetInMinutes ? timeZoneOffsetInMinutes : null}
                         style={[Style.datePicker, customStyles.datePicker]}
                       />
                     </View>


### PR DESCRIPTION
if timezoneOffset is undefined, pass null to the iOS dateTime picker. Without doing this, behaviour becomes unpredictable and the incorrect date can be returned. This is the cause of many of the related issues reported that have been hard to track down.