### PR TITLE
Fix button not showing on react-native 0.54 and newer

### DIFF
--- a/style.js
+++ b/style.js
@@ -45,7 +45,7 @@ let style = StyleSheet.create({
     position: 'absolute',
     top: 0,
     height: 42,
-    padding: 20,
+    paddingHorizontal: 20,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center'


### PR DESCRIPTION
On newer react native versions, height and vertical padding doesn't work well together, at least on iOS.