### PR TITLE
Use moment with locales

### DIFF
--- a/__tests__/Datepicker.test.js
+++ b/__tests__/Datepicker.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {Platform, Animated, DatePickerAndroid, Modal, View} from 'react-native';
 import Enzyme, {shallow} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import Moment from 'moment';
+import Moment from 'moment/min/moment-with-locales';
 import DatePicker from '../datepicker.js';
 
 Enzyme.configure({adapter: new Adapter()});
@@ -353,5 +353,12 @@ describe('Coverage', () => {
     const wrapper = shallow(<DatePicker />);
 
     wrapper.find('DatePickerIOS').simulate('dateChange');
+  });
+
+  it('Sets locale', () => {
+    jest.spyOn(Moment, 'locale');
+    shallow(<DatePicker locale="es" />);
+
+    expect(Moment.locale).toHaveBeenCalledWith('es');
   });
 });

--- a/datepicker.js
+++ b/datepicker.js
@@ -14,7 +14,7 @@ import {
   Keyboard
 } from 'react-native';
 import Style from './style';
-import Moment from 'moment';
+import Moment from 'moment/min/moment-with-locales';
 
 const FORMATS = {
   'date': 'YYYY-MM-DD',
@@ -56,6 +56,12 @@ class DatePicker extends Component {
       console.ignoredYellowBox = [];
     }
     console.ignoredYellowBox.push('Warning: Failed propType');
+  }
+
+  componentDidMount() {
+    if (this.props.locale) {
+      Moment.locale(this.props.locale);
+    }
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Use `moment/min/moment-with-locales` instead to be able to get correct date format from moment. 