### PR TITLE
Revert "Use moment with locales"

### DIFF
--- a/__tests__/Datepicker.test.js
+++ b/__tests__/Datepicker.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {Platform, Animated, DatePickerAndroid, Modal, View} from 'react-native';
 import Enzyme, {shallow} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import Moment from 'moment/min/moment-with-locales';
+import Moment from 'moment';
 import DatePicker from '../datepicker.js';
 
 Enzyme.configure({adapter: new Adapter()});
@@ -353,12 +353,5 @@ describe('Coverage', () => {
     const wrapper = shallow(<DatePicker />);
 
     wrapper.find('DatePickerIOS').simulate('dateChange');
-  });
-
-  it('Sets locale', () => {
-    jest.spyOn(Moment, 'locale');
-    shallow(<DatePicker locale="es" />);
-
-    expect(Moment.locale).toHaveBeenCalledWith('es');
   });
 });

--- a/datepicker.js
+++ b/datepicker.js
@@ -14,7 +14,7 @@ import {
   Keyboard
 } from 'react-native';
 import Style from './style';
-import Moment from 'moment/min/moment-with-locales';
+import Moment from 'moment';
 
 const FORMATS = {
   'date': 'YYYY-MM-DD',
@@ -48,12 +48,6 @@ class DatePicker extends Component {
     this.onDatetimePicked = this.onDatetimePicked.bind(this);
     this.onDatetimeTimePicked = this.onDatetimeTimePicked.bind(this);
     this.setModalVisible = this.setModalVisible.bind(this);
-  }
-
-  componentDidMount() {
-    if (this.props.locale) {
-      Moment.locale(this.props.locale);
-    }
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Reverts xgfe/react-native-datepicker#234

Globally local setting is not desirable. Even if you want to do as this way, you can set outside the Component with `Moment` gloabl API.