### PR TITLE
Replace MomentJS with native Date and DayJS as parser and formatter

### DIFF
--- a/__tests__/Datepicker.test.js
+++ b/__tests__/Datepicker.test.js
@@ -69,7 +69,7 @@ describe('DatePicker', () => {
 
     const wrapper3 = shallow(<DatePicker showIcon={false} date={{test: 123}} />);
     expect(wrapper3.find('Image').length).toEqual(0);
-    expect(wrapper3.instance().getDateStr()).toEqual('Invalid date');
+    expect(wrapper3.instance().getDateStr()).toEqual('NaN-NaN-NaN');
     expect(datePicker1._renderIcon()).toEqual(null);
 
   });

--- a/datepicker.js
+++ b/datepicker.js
@@ -14,7 +14,7 @@ import {
   Keyboard
 } from 'react-native';
 import Style from './style';
-import Moment from 'moment';
+import Dayjs from 'dayjs';
 
 const FORMATS = {
   'date': 'YYYY-MM-DD',
@@ -144,7 +144,7 @@ class DatePicker extends Component {
       return date;
     }
 
-    return Moment(date, format).toDate();
+    return Dayjs(date).toDate();
   }
 
   getDateStr(date = this.props.date) {
@@ -158,7 +158,7 @@ class DatePicker extends Component {
       return this.props.getDateStr(dateInstance);
     }
 
-    return Moment(dateInstance).format(format);
+    return Dayjs(dateInstance).format(format);
   }
 
   datePicked() {
@@ -211,7 +211,7 @@ class DatePicker extends Component {
   onTimePicked({action, hour, minute}) {
     if (action !== DatePickerAndroid.dismissedAction) {
       this.setState({
-        date: Moment().hour(hour).minute(minute).toDate()
+        date: Dayjs().set('hour', hour).set('minute', minute).toDate()
       });
       this.datePicked();
     } else {
@@ -223,11 +223,11 @@ class DatePicker extends Component {
     const {mode, androidMode, format = FORMATS[mode], is24Hour = !format.match(/h|a/)} = this.props;
 
     if (action !== DatePickerAndroid.dismissedAction) {
-      let timeMoment = Moment(this.state.date);
+      const date = this.state.date;
 
       TimePickerAndroid.open({
-        hour: timeMoment.hour(),
-        minute: timeMoment.minutes(),
+        hour: date.getHours(),
+        minute: date.getMinutes(),
         is24Hour: is24Hour,
         mode: androidMode
       }).then(this.onDatetimeTimePicked.bind(this, year, month, day));
@@ -276,11 +276,11 @@ class DatePicker extends Component {
       } else if (mode === 'time') {
         // 选时间
 
-        let timeMoment = Moment(this.state.date);
+        const date = this.state.date;
 
         TimePickerAndroid.open({
-          hour: timeMoment.hour(),
-          minute: timeMoment.minutes(),
+          hour: date.getHours(),
+          minute: date.getMinutes(),
           is24Hour: is24Hour,
           mode: androidMode
         }).then(this.onTimePicked);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/xgfe/react-native-datepicker#readme",
   "dependencies": {
-    "moment": "^2.22.0"
+    "dayjs": "^1.7.7"
   },
   "devDependencies": {
     "babel-core": "^6.5.2",
@@ -42,6 +42,7 @@
     "jest": "21.2.1",
     "jsdom": "^11.3.0",
     "jsdom-global": "^3.0.2",
+    "moment": "^2.22.0",
     "pre-commit": "^1.1.3",
     "react": "16.0.0-beta.5",
     "react-dom": "16.0.0-beta.5",


### PR DESCRIPTION
Use native Date as much as possible for readable code.

DayJS used only for parsing, formatting and setting hour and minute because `new Date(new Date().setHours(hour, minute))` is ugly.

MomenJS used only as devDependecy for 100% compatibility in testing