### PR TITLE
Add onPressConfirm event

### DIFF
--- a/datepicker.js
+++ b/datepicker.js
@@ -110,7 +110,9 @@ class DatePicker extends Component {
     this.datePicked();
     this.setModalVisible(false);
 
-    if (typeof this.props.onCloseModal === 'function') {
+    if (typeof this.props.onPressConfirm === 'function') {
+      this.props.onPressConfirm();
+    } else if (typeof this.props.onCloseModal === 'function') {
       this.props.onCloseModal();
     }
   }
@@ -484,6 +486,7 @@ DatePicker.propTypes = {
   onOpenModal: PropTypes.func,
   onCloseModal: PropTypes.func,
   onPressMask: PropTypes.func,
+  onPressConfirm: PropTypes.func,
   placeholder: PropTypes.string,
   modalOnResponderTerminationRequest: PropTypes.func,
   is24Hour: PropTypes.bool,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-datepicker",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "React Native DatePicker component for both Android and iOS, useing DatePickerAndroid, TimePickerAndroid and DatePickerIOS",
   "main": "datepicker.js",
   "scripts": {
@@ -25,28 +25,28 @@
   },
   "homepage": "https://github.com/xgfe/react-native-datepicker#readme",
   "dependencies": {
-    "moment": "^2.22.0"
+    "moment": "^2.23.0"
   },
   "devDependencies": {
-    "babel-core": "^6.5.2",
-    "babel-eslint": "^7.2.3",
-    "babel-jest": "21.2.0",
-    "babel-preset-react-native": "4.0.0",
-    "coveralls": "^2.11.9",
+    "@babel/core": "7.2.2",
+    "@babel/plugin-external-helpers": "7.2.0",
+    "@babel/plugin-proposal-decorators": "7.2.2",
+    "@babel/runtime": "7.2.0",
+    "babel-eslint": "10.0.1",
+    "babel-jest": "23.6.0",
     "cz-conventional-changelog": "^1.2.0",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.0.2",
     "eslint": "^3.19.0",
-    "eslint-plugin-react": "^7.0.1",
-    "inquirer": "^3.0.5",
+    "eslint-plugin-react": "^7.11.1",
     "jest": "21.2.1",
     "jsdom": "^11.3.0",
     "jsdom-global": "^3.0.2",
+    "metro-react-native-babel-preset": "0.50.0",
     "pre-commit": "^1.1.3",
-    "react": "16.0.0-beta.5",
-    "react-dom": "16.0.0-beta.5",
-    "react-native": "0.49.3",
-    "react-test-renderer": "16.0.0-beta.5"
+    "react": "16.6.3",
+    "react-native": "0.57.8",
+    "react-test-renderer": "16.6.3"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-datepicker",
-  "version": "1.7.3",
+  "version": "1.7.2",
   "description": "React Native DatePicker component for both Android and iOS, useing DatePickerAndroid, TimePickerAndroid and DatePickerIOS",
   "main": "datepicker.js",
   "scripts": {
@@ -25,28 +25,28 @@
   },
   "homepage": "https://github.com/xgfe/react-native-datepicker#readme",
   "dependencies": {
-    "moment": "^2.23.0"
+    "moment": "^2.22.0"
   },
   "devDependencies": {
-    "@babel/core": "7.2.2",
-    "@babel/plugin-external-helpers": "7.2.0",
-    "@babel/plugin-proposal-decorators": "7.2.2",
-    "@babel/runtime": "7.2.0",
-    "babel-eslint": "10.0.1",
-    "babel-jest": "23.6.0",
+    "babel-core": "^6.5.2",
+    "babel-eslint": "^7.2.3",
+    "babel-jest": "21.2.0",
+    "babel-preset-react-native": "4.0.0",
+    "coveralls": "^2.11.9",
     "cz-conventional-changelog": "^1.2.0",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.0.2",
     "eslint": "^3.19.0",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "^7.0.1",
+    "inquirer": "^3.0.5",
     "jest": "21.2.1",
     "jsdom": "^11.3.0",
     "jsdom-global": "^3.0.2",
-    "metro-react-native-babel-preset": "0.50.0",
     "pre-commit": "^1.1.3",
-    "react": "16.6.3",
-    "react-native": "0.57.8",
-    "react-test-renderer": "16.6.3"
+    "react": "16.0.0-beta.5",
+    "react-dom": "16.0.0-beta.5",
+    "react-native": "0.49.3",
+    "react-test-renderer": "16.0.0-beta.5"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
I've added a onPressConfirm event, to be able to distinguish between close modal and confirm pressing.

if onPressConfirm call back is not specified it will fall back to onCloseModal to keep the previous behaviour.