### PR TITLE
Keep the picker open after onPressConfirm

### DIFF
--- a/datepicker.js
+++ b/datepicker.js
@@ -108,7 +108,9 @@ class DatePicker extends Component {
 
   onPressConfirm() {
     this.datePicked();
-    this.setModalVisible(false);
+    if (!this.props.keepVisibleOnPressConfirm){
+      this.setModalVisible(false);
+    }
 
     if (typeof this.props.onCloseModal === 'function') {
       this.props.onCloseModal();


### PR DESCRIPTION
Added possibility to keep the picker open, after pressing the confirmation button (`onPressConfirm`).
The management of the picker closure can be managed manually