### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ You can check [index.js](https://github.com/xgfe/react-native-datepicker/blob/ma
 | modalOnResponderTerminationRequest | - | `function` | Set the callback for React Native's [Gesture Responder System](https://facebook.github.io/react-native/docs/gesture-responder-system.html#responder-lifecycle)'s call to `onResponderTerminationRequest`. By default this will reject a termination request, but can be overidden in case the View under the Modal is implementing custom gesture responders, and you wish for those to be overidden in certain cases.  |
 | TouchableComponent | `TouchableHighlight` | `Component` | Replace the `TouchableHighlight` with a custom `Component`. For example : `TouchableOpacity` |
 | getDateStr | - | Function | A function to override how to format the date into a `String` for display, receives a `Date` instance
+| locale | - | `string` | The locale for the date picker. Changes language, date order and am/pm preferences. Value needs to be a Locale ID. (_IOS only_)
 
 ### Property `customStyles` available keys
 


### PR DESCRIPTION
update `locale` props in readme
- reasoning: this should be included since the component supports `locale` as a prop and is not documented within the readme