### PR TITLE
Add onDateChange second date argument in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can check [index.js](https://github.com/xgfe/react-native-datepicker/blob/ma
 | is24Hour | - | `boolean` | Set the TimePicker is24Hour flag. The default value depend on `format`. Only work in Android |
 | allowFontScaling | true | `boolean` | Set to false to disable font scaling for every text component |
 | placeholder | '' | `string` | The placeholder show when this.props.date is falsy |
-| onDateChange | - | `function` | This is called when the user confirm the picked date or time in the UI. The first and only argument is a date or time string representing the new date and time formatted by [moment.js](http://momentjs.com/) with the given format property. |
+| onDateChange | - | `function` | This is called when the user confirm the picked date or time in the UI. The first argument `dateStr` is a date or time string representing the new date and time formatted by [moment.js](http://momentjs.com/) with the given format property. The second argument is a `date` that is not formatted.  |
 | onOpenModal | - | `function` | This is called when the DatePicker Modal open. |
 | onCloseModal | - | `function` | This is called when the DatePicker Modal close |
 | onPressMask | - | `function` | This is called when clicking the ios modal mask |


### PR DESCRIPTION
This adds the second `date` argument received in `onDateChange` in the documentation. It was implemented in: https://github.com/fo-am/iCrapAppPro/commit/e7680f695b29a73a836987590a1aa397688f17ce

I've had this issue: https://github.com/xgfe/react-native-datepicker/issues/269 so it will prevent people having this in the future.