### PR TITLE
Add option for onPressMaskBehaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ You can check [index.js](https://github.com/xgfe/react-native-datepicker/blob/ma
 | onOpenModal | - | `function` | This is called when the DatePicker Modal open. |
 | onCloseModal | - | `function` | This is called when the DatePicker Modal close |
 | onPressMask | - | `function` | This is called when clicking the ios modal mask |
+| onPressMask | 'cancel' | `enum` | The enum of `cancel` and `confirm`. Use `confirm` if pressing on the mask should confirm selected date |
 | modalOnResponderTerminationRequest | - | `function` | Set the callback for React Native's [Gesture Responder System](https://facebook.github.io/react-native/docs/gesture-responder-system.html#responder-lifecycle)'s call to `onResponderTerminationRequest`. By default this will reject a termination request, but can be overidden in case the View under the Modal is implementing custom gesture responders, and you wish for those to be overidden in certain cases.  |
 | TouchableComponent | `TouchableHighlight` | `Component` | Replace the `TouchableHighlight` with a custom `Component`. For example : `TouchableOpacity` |
 | getDateStr | - | Function | A function to override how to format the date into a `String` for display, receives a `Date` instance

--- a/__tests__/Datepicker.test.js
+++ b/__tests__/Datepicker.test.js
@@ -147,24 +147,48 @@ describe('DatePicker', () => {
     expect(onCloseModal).toHaveBeenCalledTimes(1);
   });
 
-  it('onPressMask', () => {
-    const onPressMask = jest.fn();
-    const wrapper = shallow(<DatePicker onPressMask={onPressMask}/>);
-    const datePicker = wrapper.instance();
+  describe('onPressMask', () => {
+    it('calls onPressMask if onPressMask is passed', () => {
+      const onPressMask = jest.fn();
+      const wrapper = shallow(<DatePicker onPressMask={onPressMask}/>);
+      const datePicker = wrapper.instance();
+  
+      datePicker.onPressMask();
+  
+      expect(onPressMask).toHaveBeenCalledTimes(1);
+    })
 
-    datePicker.onPressMask();
+    it('calls onPressCancel if onPressMask is not passed', () => {
+      const onPressCancel = jest.fn();
+      const wrapper = shallow(<DatePicker />);
+      const datePicker = wrapper.instance();
+      datePicker.onPressCancel = onPressCancel;
+  
+      datePicker.onPressMask();
+  
+      expect(onPressCancel).toHaveBeenCalledTimes(1);
+    })
 
-    expect(onPressMask).toHaveBeenCalledTimes(1);
+    it('calls onPressCancel when onPressMaskBehaviour is set to cancel and onPressMask is not passed', () => {
+      const onPressCancel = jest.fn();
+      const wrapper = shallow(<DatePicker onPressMaskBehaviour='cancel' />);
+      const datePicker = wrapper.instance();
+      datePicker.onPressCancel = onPressCancel;
 
-    // call onPressCancel when without onPressMask cb func
-    const onPressCancel = jest.fn();
-    const wrapper1 = shallow(<DatePicker />);
-    const datePicker1 = wrapper1.instance();
-    datePicker1.onPressCancel = onPressCancel;
+      datePicker.onPressMask();
 
-    datePicker1.onPressMask();
+      expect(onPressCancel).toHaveBeenCalledTimes(1);
+    })    
+    it('calls onPressConfirm when onPressMaskBehaviour is set to confirm and onPressMask is not passed', () => {
+      const onPressConfirm = jest.fn();
+      const wrapper = shallow(<DatePicker onPressMaskBehaviour='confirm' />);
+      const datePicker = wrapper.instance();
+      datePicker.onPressConfirm = onPressConfirm;
 
-    expect(onPressCancel).toHaveBeenCalledTimes(1);
+      datePicker.onPressMask();
+
+      expect(onPressConfirm).toHaveBeenCalledTimes(1);
+    })
   });
 
   it('onPressConfirm', () => {

--- a/datepicker.js
+++ b/datepicker.js
@@ -93,8 +93,10 @@ class DatePicker extends Component {
   onPressMask() {
     if (typeof this.props.onPressMask === 'function') {
       this.props.onPressMask();
+    } else if (this.props.onPressMaskBehaviour === 'confirm') {
+      this.onPressConfirm()
     } else {
-      this.onPressCancel();
+      this.onPressCancel()
     }
   }
 
@@ -483,6 +485,7 @@ DatePicker.propTypes = {
   onDateChange: PropTypes.func,
   onOpenModal: PropTypes.func,
   onCloseModal: PropTypes.func,
+  onPressMaskBehaviour: PropTypes.oneOf(['cancel', 'confirm']),
   onPressMask: PropTypes.func,
   placeholder: PropTypes.string,
   modalOnResponderTerminationRequest: PropTypes.func,


### PR DESCRIPTION
This PR makes it possible to change what happens when a user taps the mask. 

**Before**:
- Tapping mask closes out of the view, and the date selected does not persist

**After**
- If `onPressMaskBehaviour` not set or set to 'cancel'
  - Tapping mask closes out of the view, and the date selected does not persist
- If `onPressMaskBehaviour='confirm'`
  - Tapping mask closes out of the view, and the date selected persists

Addresses https://github.com/xgfe/react-native-datepicker/issues/327