### PR TITLE
new date moment to ignore timezones on just date

### DIFF
--- a/datepicker.js
+++ b/datepicker.js
@@ -144,7 +144,7 @@ class DatePicker extends Component {
       return date;
     }
 
-    return Moment(date, format).toDate();
+    return new Date(Moment(date).format(format));
   }
 
   getDateStr(date = this.props.date) {


### PR DESCRIPTION
```
console.log(format, date);
console.log(Moment(date, format).toDate());
console.log(new Date(Moment(date).format(format)));
return Moment(date,format).toDate();
```
That log shows this:
```
YYYY-MM-DD 1984-10-19
1984-10-18T22:00:00.000Z
1984-10-19T00:00:00.000Z
```
This PR should solve that.