### PR TITLE
Allow passing in a custom DatePickerIOSComponent

### DIFF
--- a/datepicker.js
+++ b/datepicker.js
@@ -402,7 +402,7 @@ class DatePicker extends Component {
                         minimumDate={minDate && this.getDate(minDate)}
                         maximumDate={maxDate && this.getDate(maxDate)}
                         onDateChange={this.onDateChange}
-                        onChange={this.onDateChange}
+                        onChange={(e, date) => this.onDateChange(date)}
                         minuteInterval={minuteInterval}
                         timeZoneOffsetInMinutes={timeZoneOffsetInMinutes ? timeZoneOffsetInMinutes : null}
                         style={[Style.datePicker, customStyles.datePicker]}

--- a/datepicker.js
+++ b/datepicker.js
@@ -341,8 +341,11 @@ class DatePicker extends Component {
       cancelBtnTestID,
       confirmBtnTestID,
       allowFontScaling,
-      locale
+      locale,
+      textColor,
     } = this.props;
+
+    const DatePickerIOSComponent = this.props.iOSDatePickerComponent || DatePickerIOS;
 
     const dateInputStyle = [
       Style.dateInput, customStyles.dateInput,
@@ -391,12 +394,15 @@ class DatePicker extends Component {
                     style={[Style.datePickerCon, {height: this.state.animatedHeight}, customStyles.datePickerCon]}
                   >
                     <View pointerEvents={this.state.allowPointerEvents ? 'auto' : 'none'}>
-                      <DatePickerIOS
+                      <DatePickerIOSComponent
                         date={this.state.date}
+                        value={this.state.date}
+                        textColor={textColor}
                         mode={mode}
                         minimumDate={minDate && this.getDate(minDate)}
                         maximumDate={maxDate && this.getDate(maxDate)}
                         onDateChange={this.onDateChange}
+                        onChange={this.onDateChange}
                         minuteInterval={minuteInterval}
                         timeZoneOffsetInMinutes={timeZoneOffsetInMinutes ? timeZoneOffsetInMinutes : null}
                         style={[Style.datePicker, customStyles.datePicker]}


### PR DESCRIPTION
For example the new https://github.com/react-native-community/datetimepicker. This is mostly to fix the problem with iOS Dark Mode where the text would turn white making it invisible in the white background.

```
import RNDatePicker from '@react-native-community/datetimepicker';

<DatePicker
    iOSDatePickerComponent={RNDatePicker}
    textColor={variables.text_color_dark}
/>
```