### PR TITLE
Import React native datetimepicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/xgfe/react-native-datepicker#readme",
   "dependencies": {
-    "moment": "^2.22.0"
+    "moment": "^2.22.0",
+    "@react-native-community/datetimepicker": "^2.6.1"
   },
   "devDependencies": {
     "babel-core": "^6.5.2",


### PR DESCRIPTION
React-native removed TimePickerAndroid from its library